### PR TITLE
Generate consts with bindgen for `sysdir_search_path_domain_mask_t`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ use sysdir::*;
 let mut path = [0; PATH_MAX as usize];
 
 let dir = sysdir_search_path_directory_t::SYSDIR_DIRECTORY_USER;
-let domain_mask = sysdir_search_path_domain_mask_t::SYSDIR_DOMAIN_MASK_LOCAL;
+let domain_mask = SYSDIR_DOMAIN_MASK_LOCAL;
 
 unsafe {
     let mut state = sysdir_start_search_path_enumeration(dir, domain_mask);

--- a/Rakefile
+++ b/Rakefile
@@ -128,6 +128,8 @@ task :bindgen do
     --allowlist-type sysdir.*
     --allowlist-var PATH_MAX
     --default-enum-style rust_non_exhaustive
+    --constified-enum sysdir_search_path_domain_mask_t
+    --no-prepend-enum-name
     cext/sysdir.h
   ]
   bindgen_io = IO.popen(bindgen)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //! let mut path = [0; PATH_MAX as usize];
 //!
 //! let dir = sysdir_search_path_directory_t::SYSDIR_DIRECTORY_USER;
-//! let domain_mask = sysdir_search_path_domain_mask_t::SYSDIR_DOMAIN_MASK_LOCAL;
+//! let domain_mask = SYSDIR_DOMAIN_MASK_LOCAL;
 //!
 //! unsafe {
 //!     let mut state = sysdir_start_search_path_enumeration(dir, domain_mask);
@@ -124,7 +124,7 @@ mod tests {
         let mut path = [0; PATH_MAX as usize];
 
         let dir = sysdir_search_path_directory_t::SYSDIR_DIRECTORY_USER;
-        let domain_mask = sysdir_search_path_domain_mask_t::SYSDIR_DOMAIN_MASK_LOCAL;
+        let domain_mask = SYSDIR_DOMAIN_MASK_LOCAL;
 
         unsafe {
             let mut state = sysdir_start_search_path_enumeration(dir, domain_mask);

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -42,16 +42,12 @@ pub enum sysdir_search_path_directory_t {
     SYSDIR_DIRECTORY_ALL_APPLICATIONS = 100,
     SYSDIR_DIRECTORY_ALL_LIBRARIES = 101,
 }
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum sysdir_search_path_domain_mask_t {
-    SYSDIR_DOMAIN_MASK_USER = 1,
-    SYSDIR_DOMAIN_MASK_LOCAL = 2,
-    SYSDIR_DOMAIN_MASK_NETWORK = 4,
-    SYSDIR_DOMAIN_MASK_SYSTEM = 8,
-    SYSDIR_DOMAIN_MASK_ALL = 65535,
-}
+pub const SYSDIR_DOMAIN_MASK_USER: sysdir_search_path_domain_mask_t = 1;
+pub const SYSDIR_DOMAIN_MASK_LOCAL: sysdir_search_path_domain_mask_t = 2;
+pub const SYSDIR_DOMAIN_MASK_NETWORK: sysdir_search_path_domain_mask_t = 4;
+pub const SYSDIR_DOMAIN_MASK_SYSTEM: sysdir_search_path_domain_mask_t = 8;
+pub const SYSDIR_DOMAIN_MASK_ALL: sysdir_search_path_domain_mask_t = 65535;
+pub type sysdir_search_path_domain_mask_t = ::core::ffi::c_uint;
 pub type sysdir_search_path_enumeration_state = ::core::ffi::c_uint;
 extern "C" {
     pub fn sysdir_start_search_path_enumeration(


### PR DESCRIPTION
This type is a mask, which means it is meant to be bit operated on.