### PR TITLE
Ship examples to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysdir"
-version = "1.2.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.2.1" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "Apache-2.0 OR MIT"
 edition = "2021"
@@ -12,7 +12,7 @@ homepage = "https://github.com/artichoke/sysdir-rs"
 description = "Rust bindings to sysdir(3) on macOS, iOS, tvOS, and watchOS"
 keywords = ["app_dirs", "apple", "known-folder", "path", "sysdir"]
 categories = ["api-bindings", "filesystem", "os::macos-apis"]
-include = ["cext/**/*", "src/**/*", "tests/**/*", "LICENSE-*", "README.md", "sysdir.3.man"]
+include = ["cext/**/*", "examples/**/*", "src/**/*", "tests/**/*", "LICENSE-*", "README.md", "sysdir.3.man"]
 
 [dependencies]
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-sysdir = "1.2.0"
+sysdir = "1.2.1"
 ```
 
 Then resolve well-known directories like this:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@
 //! ```
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/sysdir/1.2.0")]
+#![doc(html_root_url = "https://docs.rs/sysdir/1.2.1")]
 
 // Ensure code blocks in `README.md` compile
 #[cfg(all(


### PR DESCRIPTION
Prepare v1.2.1 release.