### PR TITLE
Add no-std crates.io category metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysdir"
-version = "1.2.1" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.2.2" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "Apache-2.0 OR MIT"
 edition = "2021"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/sysdir"
 homepage = "https://github.com/artichoke/sysdir-rs"
 description = "Rust bindings to sysdir(3) on macOS, iOS, tvOS, and watchOS"
 keywords = ["app_dirs", "apple", "known-folder", "path", "sysdir"]
-categories = ["api-bindings", "filesystem", "os::macos-apis"]
+categories = ["api-bindings", "filesystem", "no-std", "no-std::no-alloc", "os::macos-apis"]
 include = ["cext/**/*", "examples/**/*", "src/**/*", "tests/**/*", "LICENSE-*", "README.md", "sysdir.3.man"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-sysdir = "1.2.1"
+sysdir = "1.2.2"
 ```
 
 Then resolve well-known directories like this:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@
 //! ```
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/sysdir/1.2.1")]
+#![doc(html_root_url = "https://docs.rs/sysdir/1.2.2")]
 
 // Ensure code blocks in `README.md` compile
 #[cfg(all(


### PR DESCRIPTION
Prepare for v1.2.2 release.