### PR TITLE
Do not run tests for MSRV build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,18 +72,6 @@ jobs:
       - name: Compile
         run: cargo build --verbose
 
-      - name: Compile tests
-        run: cargo test --no-run
-
-      - name: Test
-        run: cargo test
-
-      - name: Test with all features
-        run: cargo test --all-features
-
-      - name: Test with no default features
-        run: cargo test --no-default-features
-
       - name: Check example
         run: cargo check --examples
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,15 +72,6 @@ jobs:
       - name: Compile
         run: cargo build --verbose
 
-      - name: Check example
-        run: cargo check --examples
-
-      - name: Build examples
-        run: cargo build --examples
-
-      - name: Run example
-        run: cargo run --example enumerate_system_dirs -q
-
   build-non-apple:
     name: Build (non-Apple platforms)
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
MSRV conflicts with toml v0.7.x which is pulled in by `version-sync`.

See:

- https://github.com/artichoke/qed/pull/76