### PR TITLE
Remove version-sync dependency and tests

### DIFF
--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -1,9 +1,0 @@
-#[test]
-fn test_readme_deps() {
-    version_sync::assert_markdown_deps_updated!("README.md");
-}
-
-#[test]
-fn test_html_root_url() {
-    version_sync::assert_html_root_url_updated!("src/lib.rs");
-}


### PR DESCRIPTION
`version-sync` depends on `url`. A patch version of `url` moved from `unicode-bidi` as a dep to the icu4x ecosystem which has a huge dep tree and an aggressive MSRV policy. To avoid maintenance churn, remove this dep and the associated tests.