### PR TITLE
Remove macOS 13 from CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,6 @@ jobs:
           - macos-latest
           - macos-15
           - macos-14
-          - macos-13
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: 1


### PR DESCRIPTION
macos-13 runner images are retired