### PR TITLE
Bump crate version to 1.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysdir"
-version = "1.3.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.3.1" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "Apache-2.0 OR MIT"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-sysdir = "1.3.0"
+sysdir = "1.3.1"
 ```
 
 Then resolve well-known directories like this:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@
 //! ```
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/sysdir/1.3.0")]
+#![doc(html_root_url = "https://docs.rs/sysdir/1.3.1")]
 
 // Ensure code blocks in `README.md` compile
 #[cfg(all(


### PR DESCRIPTION
## Summary
- bump crate version from `1.3.0` to `1.3.1`
- update `html_root_url` to the new version
- update README dependency snippet

## Verification
- `cargo check --locked`
