### PR TITLE
Fix rustdoc build and prepare v1.3.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysdir"
-version = "1.3.1" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.3.2" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "Apache-2.0 OR MIT"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-sysdir = "1.3.1"
+sysdir = "1.3.2"
 ```
 
 Then resolve well-known directories like this:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 //
 // This approach is borrowed from tokio.
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, feature(doc_alias))]
 
 //! Enumeration of the filesystem paths for the various standard system
 //! directories where apps, resources, etc. get installed.
@@ -92,7 +91,7 @@
 //! ```
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/sysdir/1.3.1")]
+#![doc(html_root_url = "https://docs.rs/sysdir/1.3.2")]
 
 // Ensure code blocks in `README.md` compile
 #[cfg(all(


### PR DESCRIPTION
## Summary
- remove the stale docsrs doc_alias feature gate that now fails under -D warnings
- bump the crate and docs metadata from 1.3.1 to 1.3.2
- update the README dependency snippet for the patch release

## Verification
- cargo test
- cargo +nightly test
- RUSTDOCFLAGS="-D warnings -D rustdoc::broken_intra_doc_links --cfg docsrs" cargo +nightly doc --no-deps
- cargo package --allow-dirty