### PR TITLE
[codex] Document sysdir path semantics and harden NEXT_ROOT tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysdir"
-version = "1.3.2" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.3.3" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "Apache-2.0 OR MIT"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ unsafe {
             break;
         }
         let path = CStr::from_ptr(path);
-        let s = path.to_str().unwrap();
-        assert!(s.ends_with("/Users"));
+        let bytes = path.to_bytes();
+        assert!(bytes.ends_with(b"/Users"));
     }
 }
 ```
@@ -59,9 +59,11 @@ values are not always normalized filesystem paths:
   directory
 - if `NEXT_ROOT` is set and honored by the process, many local, network, and
   system-domain results are prefixed by that directory
+- returned values are not guaranteed to be UTF-8 if `NEXT_ROOT` contains
+  non-UTF-8 bytes
 
-If you intend to use returned values with filesystem APIs, expand `~` and
-account for `NEXT_ROOT` before opening or creating files.
+If you intend to use returned values with filesystem APIs, expand `~`, account
+for `NEXT_ROOT`, and validate UTF-8 before opening or creating files.
 
 You can test this crate works on your platform by running the example:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-sysdir = "1.3.2"
+sysdir = "1.3.3"
 ```
 
 Then resolve well-known directories like this:

--- a/README.md
+++ b/README.md
@@ -47,10 +47,21 @@ unsafe {
         }
         let path = CStr::from_ptr(path);
         let s = path.to_str().unwrap();
-        assert_eq!(s, "/Users");
+        assert!(s.ends_with("/Users"));
     }
 }
 ```
+
+`sysdir-rs` exposes raw `sysdir(3)` search-path strings from Darwin. Those
+values are not always normalized filesystem paths:
+
+- user-domain results may contain a literal `~` instead of an expanded home
+  directory
+- if `NEXT_ROOT` is set and honored by the process, many local, network, and
+  system-domain results are prefixed by that directory
+
+If you intend to use returned values with filesystem APIs, expand `~` and
+account for `NEXT_ROOT` before opening or creating files.
 
 You can test this crate works on your platform by running the example:
 

--- a/examples/enumerate_system_dirs.rs
+++ b/examples/enumerate_system_dirs.rs
@@ -24,6 +24,10 @@
 
 //! Example demonstrating the sysdir well-known directory enumeration API.
 //!
+//! The output is the raw search-path strings returned by `sysdir(3)`. User
+//! domain entries may contain a literal `~`, and local, network, and system
+//! domain entries may be prefixed by `NEXT_ROOT`.
+//!
 //! # Usage
 //!
 //! ```shell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sysdir-rs"
-version = "1.3.2"
+version = "1.3.3"
 description = "Rust bindings to sysdir(3) on macOS, iOS, tvOS, and watchOS"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! ```
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/sysdir/1.3.2")]
+#![doc(html_root_url = "https://docs.rs/sysdir/1.3.3")]
 
 #[cfg(test)]
 extern crate std;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,19 @@
 //! Apple platforms. This crate does not link to `CoreFoundation`, `Foundation`,
 //! or any other system libraries and frameworks.
 //!
+//! ## Path Semantics
+//!
+//! These bindings expose raw `sysdir(3)` search-path strings from Darwin.
+//! Returned values are not normalized filesystem paths:
+//!
+//! - user-domain results may contain a literal `~` instead of an expanded home
+//!   directory
+//! - if `NEXT_ROOT` is set and honored by the process, many local, network, and
+//!   system-domain results are prefixed by that directory
+//!
+//! Callers that intend to use these values with filesystem APIs should expand
+//! `~` and account for `NEXT_ROOT` before opening or creating files.
+//!
 //! # Examples
 //!
 #![cfg_attr(
@@ -85,13 +98,17 @@
 //!         }
 //!         let path = CStr::from_ptr(path);
 //!         let s = path.to_str().unwrap();
-//!         assert_eq!(s, "/Users");
+//!         // `sysdir(3)` may prefix local-domain results with `NEXT_ROOT`.
+//!         assert!(s.ends_with("/Users"));
 //!     }
 //! }
 //! ```
 
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/sysdir/1.3.2")]
+
+#[cfg(test)]
+extern crate std;
 
 // Ensure code blocks in `README.md` compile
 #[cfg(all(
@@ -150,8 +167,23 @@ pub use self::sys::*;
 ))]
 mod tests {
     use core::ffi::{CStr, c_char};
+    use std::{borrow::Cow, env};
 
     use super::*;
+
+    fn expected_local_users_directory() -> Cow<'static, str> {
+        match env::var("NEXT_ROOT") {
+            Ok(next_root) => {
+                let next_root = next_root.trim_end_matches('/');
+                if next_root.is_empty() {
+                    Cow::Borrowed("/Users")
+                } else {
+                    Cow::Owned(std::format!("{next_root}/Users"))
+                }
+            }
+            Err(_) => Cow::Borrowed("/Users"),
+        }
+    }
 
     // EXAMPLES
     //
@@ -169,6 +201,7 @@ mod tests {
     fn example_and_linkage() {
         let mut count = 0_usize;
         let mut path = [0; PATH_MAX as usize];
+        let expected = expected_local_users_directory();
 
         let dir = sysdir_search_path_directory_t::SYSDIR_DIRECTORY_USER;
         let domain_mask = SYSDIR_DOMAIN_MASK_LOCAL;
@@ -183,7 +216,7 @@ mod tests {
                 }
                 let path = CStr::from_ptr(path);
                 let s = path.to_str().unwrap();
-                assert_eq!(s, "/Users");
+                assert_eq!(s, expected.as_ref());
                 count += 1;
             }
         }
@@ -195,6 +228,7 @@ mod tests {
     fn example_and_linkage_with_opaque_state_helpers() {
         let mut count = 0_usize;
         let mut path = [0; PATH_MAX as usize];
+        let expected = expected_local_users_directory();
 
         let dir = sysdir_search_path_directory_t::SYSDIR_DIRECTORY_USER;
         let domain_mask = SYSDIR_DOMAIN_MASK_LOCAL;
@@ -209,7 +243,7 @@ mod tests {
                 }
                 let path = CStr::from_ptr(path);
                 let s = path.to_str().unwrap();
-                assert_eq!(s, "/Users");
+                assert_eq!(s, expected.as_ref());
                 count += 1;
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,9 +55,12 @@
 //!   directory
 //! - if `NEXT_ROOT` is set and honored by the process, many local, network, and
 //!   system-domain results are prefixed by that directory
+//! - callers should not assume returned values are valid UTF-8 if `NEXT_ROOT`
+//!   contains non-UTF-8 bytes
 //!
 //! Callers that intend to use these values with filesystem APIs should expand
-//! `~` and account for `NEXT_ROOT` before opening or creating files.
+//! `~`, account for `NEXT_ROOT`, and validate UTF-8 before opening or creating
+//! files.
 //!
 //! # Examples
 //!
@@ -97,9 +100,10 @@
 //!             break;
 //!         }
 //!         let path = CStr::from_ptr(path);
-//!         let s = path.to_str().unwrap();
-//!         // `sysdir(3)` may prefix local-domain results with `NEXT_ROOT`.
-//!         assert!(s.ends_with("/Users"));
+//!         let bytes = path.to_bytes();
+//!         // `sysdir(3)` may prefix local-domain results with `NEXT_ROOT`,
+//!         // which can also introduce non-UTF-8 bytes.
+//!         assert!(bytes.ends_with(b"/Users"));
 //!     }
 //! }
 //! ```
@@ -167,21 +171,29 @@ pub use self::sys::*;
 ))]
 mod tests {
     use core::ffi::{CStr, c_char};
+    use std::os::unix::ffi::OsStrExt;
     use std::{borrow::Cow, env};
 
     use super::*;
 
-    fn expected_local_users_directory() -> Cow<'static, str> {
-        match env::var("NEXT_ROOT") {
-            Ok(next_root) => {
-                let next_root = next_root.trim_end_matches('/');
+    fn expected_local_users_directory() -> Cow<'static, [u8]> {
+        match env::var_os("NEXT_ROOT") {
+            Some(next_root) => {
+                let next_root = next_root.as_os_str().as_bytes();
+                let next_root = next_root
+                    .iter()
+                    .rposition(|&byte| byte != b'/')
+                    .map_or(&[][..], |pos| &next_root[..=pos]);
                 if next_root.is_empty() {
-                    Cow::Borrowed("/Users")
+                    Cow::Borrowed(b"/Users")
                 } else {
-                    Cow::Owned(std::format!("{next_root}/Users"))
+                    let mut path = std::vec::Vec::with_capacity(next_root.len() + b"/Users".len());
+                    path.extend_from_slice(next_root);
+                    path.extend_from_slice(b"/Users");
+                    Cow::Owned(path)
                 }
             }
-            Err(_) => Cow::Borrowed("/Users"),
+            None => Cow::Borrowed(b"/Users"),
         }
     }
 
@@ -215,8 +227,8 @@ mod tests {
                     break;
                 }
                 let path = CStr::from_ptr(path);
-                let s = path.to_str().unwrap();
-                assert_eq!(s, expected.as_ref());
+                let bytes = path.to_bytes();
+                assert_eq!(bytes, expected.as_ref());
                 count += 1;
             }
         }
@@ -242,8 +254,8 @@ mod tests {
                     break;
                 }
                 let path = CStr::from_ptr(path);
-                let s = path.to_str().unwrap();
-                assert_eq!(s, expected.as_ref());
+                let bytes = path.to_bytes();
+                assert_eq!(bytes, expected.as_ref());
                 count += 1;
             }
         }

--- a/tests/next_root.rs
+++ b/tests/next_root.rs
@@ -1,0 +1,29 @@
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos"
+))]
+#[test]
+fn lib_tests_and_doctests_pass_with_next_root_set() {
+    use std::process::Command;
+
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    for args in [["test", "--lib"], ["test", "--doc"]] {
+        let output = Command::new(&cargo)
+            .args(args)
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .env("NEXT_ROOT", "/tmp/sysdir-next-root-test")
+            .output()
+            .expect("should run cargo test in a subprocess");
+
+        assert!(
+            output.status.success(),
+            "cargo {} failed with NEXT_ROOT set\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+            args.join(" "),
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+}

--- a/tests/next_root.rs
+++ b/tests/next_root.rs
@@ -4,8 +4,7 @@
     target_os = "tvos",
     target_os = "watchos"
 ))]
-#[test]
-fn lib_tests_and_doctests_pass_with_next_root_set() {
+fn assert_tests_pass_with_next_root(next_root: impl AsRef<std::ffi::OsStr>, context: &str) {
     use std::process::Command;
 
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
@@ -13,17 +12,42 @@ fn lib_tests_and_doctests_pass_with_next_root_set() {
         let output = Command::new(&cargo)
             .args(args)
             .current_dir(env!("CARGO_MANIFEST_DIR"))
-            .env("NEXT_ROOT", "/tmp/sysdir-next-root-test")
+            .env("NEXT_ROOT", next_root.as_ref())
             .output()
             .expect("should run cargo test in a subprocess");
 
         assert!(
             output.status.success(),
-            "cargo {} failed with NEXT_ROOT set\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+            "cargo {} failed with {context}\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
             args.join(" "),
             output.status,
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr),
         );
     }
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos"
+))]
+#[test]
+fn lib_tests_and_doctests_pass_with_next_root_set() {
+    assert_tests_pass_with_next_root("/tmp/sysdir-next-root-test", "NEXT_ROOT set");
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos"
+))]
+#[test]
+fn lib_tests_and_doctests_pass_with_non_utf8_next_root_set() {
+    use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+
+    let next_root = OsString::from_vec(b"/tmp/sysdir-next-root-\xff-test".to_vec());
+    assert_tests_pass_with_next_root(next_root, "NEXT_ROOT set to non-UTF-8 bytes");
 }


### PR DESCRIPTION
## Summary

This PR hardens `sysdir-rs` against Darwin `sysdir(3)` path rewriting semantics in tests and docs.

- add an integration regression that runs lib tests and doctests with `NEXT_ROOT` set
- make the unit tests derive the expected local-domain `/Users` path from `NEXT_ROOT` instead of hard-coding it
- document that returned values are raw `sysdir(3)` search-path strings, including literal `~` in user-domain results and `NEXT_ROOT` prefixes in local, network, and system domains

## Why

`sysdir(3)` does not always return normalized filesystem paths. The crate docs and tests previously implied otherwise by asserting exact absolute paths like `/Users`.

That created two downstream hazards:

- `NEXT_ROOT` can redirect callers into attacker-chosen roots if they trust returned paths as stable absolute locations
- user-domain results can contain a literal `~`, which Rust path APIs do not expand automatically

## Root Cause

The crate binds raw Darwin `sysdir(3)` output, but the test and documentation examples assumed normalized, environment-insensitive paths.

## Validation

- `cargo test`
- `NEXT_ROOT=/tmp/sysdir-next-root-test cargo test`
- `cargo fmt --check`

Closes #123.
