### PR TITLE
Fix workflow security findings

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -35,9 +35,14 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          toolchain: stable
+        shell: bash
+        run: |
+          set -euo pipefail
+          rustup set profile minimal
+          rustup toolchain install stable --no-self-update
+          rustup default stable
+          rustc -Vv
+          cargo -V
 
       - name: Generate Cargo.lock
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,9 +35,14 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          toolchain: stable
+        shell: bash
+        run: |
+          set -euo pipefail
+          rustup set profile minimal
+          rustup toolchain install stable --no-self-update
+          rustup default stable
+          rustc -Vv
+          cargo -V
 
       - name: Compile
         run: cargo build --verbose
@@ -77,9 +82,14 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          toolchain: "1.85.0"
+        shell: bash
+        run: |
+          set -euo pipefail
+          rustup set profile minimal
+          rustup toolchain install 1.85.0 --no-self-update
+          rustup default 1.85.0
+          rustc -Vv
+          cargo -V
 
       - name: Compile
         run: cargo build --verbose
@@ -101,9 +111,14 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          toolchain: stable
+        shell: bash
+        run: |
+          set -euo pipefail
+          rustup set profile minimal
+          rustup toolchain install stable --no-self-update
+          rustup default stable
+          rustc -Vv
+          cargo -V
 
       - name: Compile
         run: cargo build --verbose
@@ -149,10 +164,14 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          components: rustfmt,clippy
-          toolchain: stable
+        shell: bash
+        run: |
+          set -euo pipefail
+          rustup set profile minimal
+          rustup toolchain install stable --component rustfmt --component clippy --no-self-update
+          rustup default stable
+          rustc -Vv
+          cargo -V
 
       - name: Check formatting
         run: cargo fmt --check

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -40,9 +40,14 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          toolchain: nightly
+        shell: bash
+        run: |
+          set -euo pipefail
+          rustup set profile minimal
+          rustup toolchain install nightly --no-self-update
+          rustup default nightly
+          rustc -Vv
+          cargo -V
 
       - name: Check docs with no default features
         run: cargo doc --workspace --no-default-features


### PR DESCRIPTION
## Summary

Replace the remaining dtolnay/rust-toolchain action uses with explicit rustup commands in CI, audit, and documentation workflows.

This keeps the same stable, MSRV, component, and nightly toolchain setup while removing the action dependency that zizmor reports as superfluous on hosted runners. Removing the action also clears the related hash pin version-comment mismatch findings.

## Validation

- mise exec -- npx prettier --check '.github/workflows/*.yaml'
- uv run yamllint --strict --format github .github/workflows
- uvx zizmor --persona pedantic .github/workflows
- cargo check --workspace