### PR TITLE
chore: add Codex worktree setup

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -1,0 +1,11 @@
+version = 1
+name = "sysdir-rs"
+
+[setup]
+script = "./scripts/setup_codex_worktree.sh"
+
+[setup.win32]
+script = """
+Write-Error "sysdir-rs worktree setup is supported on macOS and Linux only."
+exit 69
+"""

--- a/scripts/setup_codex_worktree.sh
+++ b/scripts/setup_codex_worktree.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Prepare a fresh Codex app worktree for local development.
+#
+# Codex invokes this through .codex/environments/environment.toml when it creates
+# a new worktree. Keep it idempotent: every command should be safe to run more
+# than once in the same checkout.
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+RESET="" INFO="" WARN="" ERR=""
+if [[ -t 1 && ${CI:-false} != "true" ]]; then
+  INFO=$'\e[1;34m'
+  WARN=$'\e[1;33m'
+  ERR=$'\e[1;31m'
+  RESET=$'\e[0m'
+fi
+
+log() { printf "%s[INFO ]%s %s\n" "$INFO" "$RESET" "$*"; }
+warn() { printf "%s[WARN ]%s %s\n" "$WARN" "$RESET" "$*" >&2; }
+error() { printf "%s[ERROR]%s %s\n" "$ERR" "$RESET" "$*" >&2; }
+
+die() {
+  error "$1"
+  exit "${2:-70}"
+}
+
+need() {
+  command -v "$1" > /dev/null 2>&1 || die "'$1' not found" 69
+}
+
+trap 'error "Failure on or near line $LINENO"; exit 70' ERR
+trap 'log "completed in ${SECONDS}s"' EXIT
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
+cd_repo_root() {
+  local repo_root
+
+  need git
+  repo_root=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
+  cd "$repo_root"
+}
+
+setup_git_base() {
+  local -a args
+  local head_sha upstream upstream_sha
+
+  args=("$@")
+  upstream=refs/remotes/origin/trunk
+
+  log "fetching latest origin/trunk"
+  git fetch --prune origin "+refs/heads/trunk:${upstream}"
+
+  head_sha=$(git rev-parse --verify "HEAD^{commit}")
+  upstream_sha=$(git rev-parse --verify "${upstream}^{commit}")
+
+  if [[ $head_sha == "$upstream_sha" ]]; then
+    log "worktree is based on origin/trunk at ${upstream_sha:0:12}"
+    return
+  fi
+
+  if [[ -n $(git status --porcelain --untracked-files=normal) ]]; then
+    die "worktree has local changes; refusing to update base to origin/trunk"
+  fi
+
+  if ! git merge-base --is-ancestor HEAD "$upstream"; then
+    die "current HEAD is not an ancestor of origin/trunk; refusing to rewrite local commits"
+  fi
+
+  log "fast-forwarding worktree to origin/trunk at ${upstream_sha:0:12}"
+  git merge --ff-only "$upstream"
+
+  log "restarting setup script after refreshing worktree base"
+  exec "$PWD/scripts/setup_codex_worktree.sh" "${args[@]}"
+}
+
+setup_mise() {
+  need mise
+
+  log "trusting mise.toml"
+  mise trust --yes mise.toml
+
+  log "checking mise-managed tools"
+  if mise install --dry-run-code; then
+    log "mise-managed tools are already installed"
+  else
+    case $? in
+      1)
+        log "installing missing mise-managed tools"
+        mise install --yes
+        ;;
+      *)
+        die "failed to check mise-managed tools"
+        ;;
+    esac
+  fi
+
+  eval "$(mise env -s bash)"
+}
+
+setup_rust() {
+  need cargo
+
+  log "fetching Rust dependencies"
+  cargo fetch
+}
+
+setup_node() {
+  if [[ ! -f package.json || ! -f package-lock.json ]]; then
+    warn "skipping npm ci because package.json or package-lock.json is missing"
+    return
+  fi
+
+  need npm
+
+  log "installing Node dependencies"
+  npm ci
+}
+
+main() {
+  cd_repo_root
+  setup_git_base "$@"
+  setup_mise
+  setup_rust
+  setup_node
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds a Codex environment descriptor and an idempotent worktree setup script for this repository.

The setup script follows the shape used in the homelab repository, but only performs the steps this crate needs: refresh from `origin/trunk`, trust and install the `mise.toml` toolchain, fetch Cargo dependencies, and install Node dependencies with `npm ci` from the checked-in lockfile.

## Impact

New Codex app worktrees for `sysdir-rs` can prepare the Rust and Node tooling automatically before local development starts.

## Validation

- `bash -n scripts/setup_codex_worktree.sh`
- `scripts/setup_codex_worktree.sh`