### PR TITLE
Update dependency tool pins

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@ rust = { version = "stable", profile = "minimal", components = "clippy,rustfmt" 
 zizmor = "1.25.2"
 
 "cargo:bindgen-cli" = "0.72.1"
-"cargo:cargo-deny" = "0.19.6"
+"cargo:cargo-deny" = "0.19.8"
 
 [hooks]
 postinstall = "corepack enable"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "rust"
   ],
   "repository": "github:artichoke/sysdir-rs",
-  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d",
+  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1",
   "author": "Ryan Lopopolo <rjl@hyperbo.la> (https://hyperbo.la/)",
   "homepage": "https://www.artichokeruby.org",
   "bugs": "https://github.com/artichoke/sysdir-rs/issues",


### PR DESCRIPTION
## Change class

Dependencies, CI, and automation maintenance.

## What changed

- Updated `cargo:cargo-deny` in `mise.toml` from `0.19.6` to `0.19.8`.
- Updated the pnpm `packageManager` pin in `package.json` from `11.1.3` to `11.5.0` with the matching Corepack SHA-512 hash.

## Cooldown decisions

- Adopted `cargo-deny` `0.19.8`, published 2026-05-28, which is older than the one-week cooldown for this 2026-06-06 run.
- Adopted `pnpm` `11.5.0`, published 2026-05-29T15:35:17Z, which is older than the one-week cooldown for this 2026-06-06 run.
- Left `pnpm` `11.5.2` alone because it was published 2026-06-05 and is inside the cooldown window.
- Left Node.js at `24.16.0`, the latest LTS from the Node dist index.
- Left `zizmor` at `1.25.2`, `bindgen-cli` at `0.72.1`, and Prettier at `3.8.3` because they are current for their ownership surfaces.

## Dependabot review

- Reviewed open Dependabot PR #144 for the GitHub Actions dependency group.
- The PR is mechanical and CI/Audit are passing.
- Attempted to enable auto-merge, but GitHub rejected the request because the pull request is already in clean status, so no merge action was taken by this automation run.

## Compatibility impact

No public API, target-support, path-semantic, generated binding, MSRV, or release metadata impact. This only updates development tooling and package-manager bootstrap pins.

## Validation

- `git diff --check`
- `cargo fmt --check`
- `pnpm install --lockfile-only` with pnpm `11.5.0`
- `pnpm install --frozen-lockfile --store-dir /private/tmp/sysdir-rs-pnpm-store` with pnpm `11.5.0`
- `pnpm dlx --package prettier@3.8.3 prettier --check '**/*'`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --all-features --all-targets`
- `cargo-deny 0.19.8`
- `cargo deny --locked --all-features check bans licenses sources --show-stats`
