### PR TITLE
Update dependency sweep tool pins

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,8 +1,8 @@
 [tools]
-node = "24.17.0"
+node = "24.18.0"
 # Rust intentionally tracks the stable channel for this Rust library.
 rust = { version = "stable", profile = "minimal", components = "clippy,rustfmt" }
-zizmor = "1.25.2"
+zizmor = "1.26.1"
 
 "cargo:bindgen-cli" = "0.72.1"
 "cargo:cargo-deny" = "0.19.9"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "rust"
   ],
   "repository": "github:artichoke/sysdir-rs",
-  "packageManager": "pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26",
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "author": "Ryan Lopopolo <rjl@hyperbo.la> (https://hyperbo.la/)",
   "homepage": "https://www.artichokeruby.org",
   "bugs": "https://github.com/artichoke/sysdir-rs/issues",


### PR DESCRIPTION
## Summary

- Update the local Node.js LTS pin from `24.17.0` to `24.18.0`.
- Update the local Zizmor pin from `1.25.2` to `1.26.1`.
- Update the Corepack pnpm pin from `11.8.0` to `11.9.0` with the npm registry sha512 digest.
- Regenerated `pnpm-lock.yaml` with pnpm `11.9.0`; it is unchanged from `trunk`.

## Change Class And Compatibility

- Change class: Dependencies, CI, and Automation.
- Compatibility impact: development-tooling only; no public API, MSRV, target-support, binding, or path-semantics change.

## Upstream Review

- Node.js `24.18.0` is the latest Krypton LTS release in the official Node distribution index, dated 2026-06-23, and is past the one-week cooldown.
- pnpm `11.9.0` was published to the npm registry on 2026-06-23; the package manager digest in `package.json` is derived from the registry `sha512` integrity.
- Zizmor `1.26.1` was published on 2026-06-21 and is past cooldown. I reviewed `zizmorcore/zizmor` `v1.25.2...v1.26.1`; this is a broad analyzer update with new audits and parser/config changes, validated locally against this repository.
- `cargo-deny` remains current at `0.19.9`; `bindgen-cli` remains current at `0.72.1`.
- Dependabot PR #151, Prettier `3.8.3 -> 3.8.4`, was reviewed and merged because it was mechanical and green.
- Dependabot PR #150 was reviewed and left open for human review because it bundles an `actions/checkout` semver-major update with a large generated action bundle rewrite and behavior changes.

## Validation

- `mise install`
- `mise exec -- node --version` => `v24.18.0`
- `mise exec -- zizmor --version` => `zizmor 1.26.1`
- `COREPACK_HOME=/private/tmp/sysdir-rs-corepack mise exec -- pnpm --version` => `11.9.0`
- `COREPACK_HOME=/private/tmp/sysdir-rs-corepack mise exec -- pnpm install --lockfile-only --ignore-scripts`
- `COREPACK_HOME=/private/tmp/sysdir-rs-corepack mise exec -- pnpm install --frozen-lockfile --ignore-scripts`
- `COREPACK_HOME=/private/tmp/sysdir-rs-corepack mise exec -- pnpm exec prettier --check '**/*'`
- `mise exec -- cargo fmt --check`
- `mise exec -- cargo build --workspace`
- `mise exec -- cargo test --workspace`
- `mise exec -- cargo clippy --workspace --all-features --all-targets`
- `mise exec -- cargo deny check bans licenses sources`
- `mise exec -- zizmor --persona pedantic . --no-progress --format plain --no-online-audits`