### PR TITLE
chore(deps): run zizmor action from mise pin

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -68,7 +68,19 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve zizmor version
+        id: zizmor-version
+        shell: bash
+        run: |
+          version="$(awk -F '"' '/^[[:space:]]*zizmor[[:space:]]*=/{ print $2; exit }' mise.toml)"
+          if [[ ! "${version}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            echo "Unable to resolve exact zizmor version from mise.toml" >&2
+            exit 1
+          fi
+          printf 'version=%s\n' "${version}" >> "${GITHUB_OUTPUT}"
+
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
           persona: "pedantic"
+          version: ${{ steps.zizmor-version.outputs.version }}

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 node = "24.17.0"
 # Rust intentionally tracks the stable channel for this Rust library.
 rust = { version = "stable", profile = "minimal", components = "clippy,rustfmt" }
-zizmor = "1.25.2"
+zizmor = "1.26.1"
 
 "cargo:bindgen-cli" = "0.72.1"
 "cargo:cargo-deny" = "0.19.9"


### PR DESCRIPTION
## Summary

- resolve the zizmor CLI version from `mise.toml` in the audit workflow
- pass the resolved version to `zizmorcore/zizmor-action`
- update the action to v0.5.7 so the current 1.26.1 CLI pin is recognized
- update the canonical `mise.toml` zizmor pin to 1.26.1

## Change Class

Dependencies, CI, and automation.

## Compatibility Impact

CI/tooling only. This does not change the public crate API, runtime behavior, directory lookup behavior, MSRV, or release metadata.

## Validation

- `awk` extraction resolves `version=1.26.1` and rejects non-exact versions
- `git diff --check`
- `mise exec -- pnpm exec prettier --check .github/workflows/audit.yaml mise.toml`
- `mise exec -- zizmor --pedantic --no-progress --cache-dir /private/tmp/... .github/workflows/audit.yaml`

Rust tests were not run because this only changes audit workflow/tool pinning.