### PR TITLE
Update dependency sweep tool pins

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@ rust = { version = "stable", profile = "minimal", components = "clippy,rustfmt" 
 zizmor = "1.26.1"
 
 "cargo:bindgen-cli" = "0.72.1"
-"cargo:cargo-deny" = "0.19.9"
+"cargo:cargo-deny" = "0.20.2"
 
 [hooks]
 postinstall = "corepack enable"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "rust"
   ],
   "repository": "github:artichoke/sysdir-rs",
-  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
+  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882",
   "author": "Ryan Lopopolo <rjl@hyperbo.la> (https://hyperbo.la/)",
   "homepage": "https://www.artichokeruby.org",
   "bugs": "https://github.com/artichoke/sysdir-rs/issues",


### PR DESCRIPTION
## Summary

Change class: Dependencies, CI, and Automation maintenance.

- Update the local cargo-deny tool pin from `0.19.9` to `0.20.2` in `mise.toml`.
- Update the Corepack pnpm package-manager pin from `11.9.0` to `11.11.0` in `package.json`.
- Leave `pnpm-lock.yaml` unchanged after a pnpm 11.11.0 lockfile-only refresh.

Compatibility impact: no public Rust API, MSRV, target support, platform behavior, generated binding, or release metadata changes. This only changes local development and automation tooling pins.

## Upstream Review

- Reviewed cargo-deny `0.19.9...0.20.2`: https://github.com/EmbarkStudios/cargo-deny/compare/0.19.9...0.20.2
  - Release notes call out CLI refactoring, a new `bans.std-replacements` lint, non-default build-script path handling, and snapshot fixes.
  - The repository's `cargo-deny --locked --all-features check ...` commands still pass with the existing `deny.toml`.
- Reviewed pnpm `11.9.0...11.11.0`: https://github.com/pnpm/pnpm/compare/v11.9.0...v11.11.0
  - Release notes include package-manager hardening, resolver fixes, and memory improvements.
  - The pnpm package still has `node >=22.13`, no direct dependency list, and the same `pnpm`/`pnpx` bin shape.

## Cooldown Decisions

- Adopted cargo-deny `0.20.2`, published 2026-07-09T17:58:46Z, after the one-week cooldown.
- Adopted pnpm `11.11.0`, published 2026-07-09T20:43:29Z, after the one-week cooldown.
- Held pnpm `11.12.0`, `11.13.0`, and `11.13.1` because they are still inside cooldown.
- Held Zizmor `1.27.0`, published 2026-07-14T08:31:10Z, because it is still inside cooldown.
- Left Node.js at `24.18.0`; it remains the latest Node 24 LTS release in Node's release index.
- Left bindgen-cli at `0.72.1`; crates.io still reports it as current.
- Left Prettier unchanged because direct Node dependency bumps are Dependabot-owned by the runbook.

## Dependabot PRs Reviewed

- Merged #154 after upstream review and green CI. The grouped GitHub Actions bump was mechanical for this repository:
  - `actions/checkout` v7 adds `pull_request_target`/`workflow_run` fork-checkout protection, but this repo uses `push`, `pull_request`, and tag-push workflows.
  - `EmbarkStudios/cargo-deny-action`, `pnpm/action-setup`, and `rust-lang/crates-io-auth-action` were patch/tool refreshes.

## Validation

- `mise install`
- `mise exec -- node -v` (`v24.18.0`)
- `COREPACK_HOME=/Users/lopopolo/.npm/corepack mise exec -- pnpm --version` (`11.11.0`)
- `mise exec -- cargo-deny --version` (`cargo-deny 0.20.2`)
- `COREPACK_HOME=/Users/lopopolo/.npm/corepack mise exec -- pnpm install --lockfile-only`
- `COREPACK_HOME=/Users/lopopolo/.npm/corepack mise exec -- pnpm install --frozen-lockfile`
- `git diff --check -- mise.toml package.json`
- `cargo fmt --check`
- `COREPACK_HOME=/Users/lopopolo/.npm/corepack mise exec -- pnpm exec prettier --check '**/*'`
- `cargo generate-lockfile --verbose` for local audit validation only; generated lockfile was removed afterward.
- `mise exec -- cargo-deny --locked --all-features check bans licenses sources --show-stats`
- `mise exec -- cargo-deny --locked --all-features check advisories --show-stats`
- `RUSTFLAGS='-D warnings' mise exec -- cargo build --workspace`
- `RUSTFLAGS='-D warnings' mise exec -- cargo test --workspace`
- `RUSTFLAGS='-D warnings' mise exec -- cargo clippy --workspace --all-features --all-targets`
- `mise exec -- zizmor --persona pedantic .github/workflows`

Note: this sandboxed linked worktree still cannot create `.git/worktrees/.../index.lock`, so the branch commit was created through GitHub Git data APIs from current `trunk`.