### PR TITLE
Update pnpm tool pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "rust"
   ],
   "repository": "github:artichoke/sysdir-rs",
-  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882",
+  "packageManager": "pnpm@11.12.0+sha512.820a6fbd0d9f04c226638002aead1e45340a9139dd5dc077c1d83ef44aa2481c8eb6637b4c9aa696a3c7e35ba818e49cf27213e5f2b91138d09b7a3e26e898ba",
   "author": "Ryan Lopopolo <rjl@hyperbo.la> (https://hyperbo.la/)",
   "homepage": "https://www.artichokeruby.org",
   "bugs": "https://github.com/artichoke/sysdir-rs/issues",


### PR DESCRIPTION
## Summary

- update the Corepack `packageManager` pin from pnpm 11.11.0 to 11.12.0
- refresh `pnpm-lock.yaml` with pnpm 11.12.0; it remains unchanged
- preserve the crate API, MSRV, platform support, and runtime dependency posture

## Upstream review

Reviewed the [pnpm 11.12 release](https://github.com/pnpm/pnpm/releases/tag/v11.12.0) and [v11.11.0...v11.12.0 compare](https://github.com/pnpm/pnpm/compare/v11.11.0...v11.12.0). The upstream release notes initially appeared low risk for this repository's single pinned Prettier dependency, and pnpm 11.12.0 retains a compatible Node requirement.

GitHub CI subsequently showed that pnpm 11.12.0 is not currently viable with this repository's pinned `pnpm/action-setup`: its self-installer crashes while building the install graph. The registry now marks pnpm 11.12.0 deprecated. This PR remains draft and requires human review.

## Cooldown

- pnpm 11.12.0 was published on July 11 and passed the one-week cooldown
- held pnpm 11.13.0 through 11.15.1 and Zizmor 1.27.0 because they remain inside cooldown
- Node.js 24.18.0, cargo-deny 0.20.2, and bindgen CLI 0.72.1 remain current

## Dependabot review

No open Dependabot pull requests were present at the start of this sweep.

## Validation

Passed locally:

- `mise install`
- Node.js `v24.18.0` and pnpm `11.12.0` version checks
- `pnpm install --lockfile-only`
- `pnpm install --frozen-lockfile`
- pnpm supply-chain policy checks
- `git diff --check`
- `cargo fmt --check`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --all-features --all-targets`
- `pnpm exec prettier --check '**/*'`
- both cargo-deny audit groups
- `zizmor --persona pedantic .github/workflows`

GitHub Actions completed with 12 passing checks and one failure: `CI / Lint and format text` fails during `pnpm/action-setup` before dependency installation.