### PR TITLE
Update pnpm tool pin

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 node = "24.18.0"
 # Rust intentionally tracks the stable channel for this Rust library.
 rust = { version = "stable", profile = "minimal", components = "clippy,rustfmt" }
-zizmor = "1.27.0"
+zizmor = "1.26.1"
 
 "cargo:bindgen-cli" = "0.72.1"
 "cargo:cargo-deny" = "0.20.2"

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 node = "24.18.0"
 # Rust intentionally tracks the stable channel for this Rust library.
 rust = { version = "stable", profile = "minimal", components = "clippy,rustfmt" }
-zizmor = "1.26.1"
+zizmor = "1.27.0"
 
 "cargo:bindgen-cli" = "0.72.1"
 "cargo:cargo-deny" = "0.20.2"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "rust"
   ],
   "repository": "github:artichoke/sysdir-rs",
-  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882",
+  "packageManager": "pnpm@11.15.1+sha512.81350b07e53c9538a02f1f2303b4290fa2d7be04e56e2a970c4cc4b417dc761de196edabd49d55c7dc9580db81007c44143e4e3d7e462b3000d23c255122d065",
   "author": "Ryan Lopopolo <rjl@hyperbo.la> (https://hyperbo.la/)",
   "homepage": "https://www.artichokeruby.org",
   "bugs": "https://github.com/artichoke/sysdir-rs/issues",


### PR DESCRIPTION
## Summary

- update the Corepack package-manager pin from pnpm 11.11.0 to 11.15.1
- refresh `pnpm-lock.yaml` with pnpm 11.15.1 (no lockfile changes)

This is Dependencies, CI, and Automation maintenance. It does not change the public API, MSRV, target support, FFI surface, or release behavior.

## Upstream review and risk

Reviewed [pnpm v11.11.0...v11.15.1](https://github.com/pnpm/pnpm/compare/v11.11.0...v11.15.1) and the release notes for 11.13.0 through 11.15.1. The target is non-deprecated, ships as a self-contained npm package, supports Node.js >=22.13, and includes installer safeguards following the broken 11.12.0 and 11.13.0 releases. For this repository, pnpm only installs the pinned Prettier dependency, so this is a low-risk development-tool update after local frozen-install and GitHub Actions validation.

## Cooldown

- pnpm 11.15.1 was published 2026-07-19 and has cleared the seven-day cooldown. pnpm 11.16.0 and 11.17.0 remain inside cooldown.
- Node.js 24.18.0, cargo-deny 0.20.2, and bindgen CLI 0.72.1 remain current.
- Zizmor remains at 1.26.1 because the repository's pinned `zizmor-action` v0.5.7 does not support 1.27.0; GitHub Actions updates remain Dependabot-owned.
- The deprecated pnpm 11.12.0 update from closed PR #157 was not repeated.

## Validation

- `mise install`
- Node.js 24.18.0 and pnpm 11.15.1 version checks
- `pnpm install --lockfile-only`
- `pnpm install --frozen-lockfile`
- `git diff --check`
- `pnpm exec prettier --check '**/*'`
- `cargo fmt --check`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --all-features --all-targets`
- `cargo deny --locked --all-features check advisories --show-stats`
- `cargo deny --locked --all-features check bans licenses sources --show-stats`
- `zizmor --persona pedantic .`

There were no open Dependabot pull requests at the start of this sweep.