### PR TITLE
ci: audit Node.js tooling dependencies

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: read # required to checkout repository
     outputs:
+      js: ${{ steps.changes.outputs.js }}
       rust: ${{ steps.changes.outputs.rust }}
       workflows: ${{ steps.changes.outputs.workflows }}
     steps:
@@ -34,10 +35,18 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           changed_files="$(git diff --name-only "$BASE_SHA...$HEAD_SHA")"
+          js=false
           rust=false
           workflows=false
 
           while IFS= read -r file; do
+            if [[ "$file" == "package.json" ||
+                  "$file" == "pnpm-lock.yaml" ||
+                  "$file" == "pnpm-workspace.yaml" ||
+                  "$file" == "mise.toml" ||
+                  "$file" == ".github/workflows/audit.yaml" ]]; then
+              js=true
+            fi
             if [[ "$file" == *.rs ||
                   "$file" == "Cargo.toml" ||
                   "$file" == "Cargo.lock" ||
@@ -52,6 +61,7 @@ jobs:
             fi
           done <<< "$changed_files"
 
+          printf 'js=%s\n' "$js" >> "$GITHUB_OUTPUT"
           printf 'rust=%s\n' "$rust" >> "$GITHUB_OUTPUT"
           printf 'workflows=%s\n' "$workflows" >> "$GITHUB_OUTPUT"
 
@@ -101,6 +111,38 @@ jobs:
           arguments: --locked --all-features
           command: check bans licenses sources
           command-arguments: --show-stats
+
+  js:
+    name: Audit JS Dependencies
+    needs: changes
+    if: >-
+      always() &&
+      (github.event_name == 'schedule' || needs.changes.outputs.js == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # required to checkout repository
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24.18.0"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: pnpm audit
+        run: pnpm audit
 
   zizmor:
     name: Run zizmor 🌈


### PR DESCRIPTION
## Summary

- audit the locked pnpm tooling alongside the existing Rust audit
- run the JS audit only for Node manifest, lockfile, toolchain, or audit changes
- retain complete weekly dependency and workflow coverage

## Impact

This is CI-only and does not change the crate API, MSRV, platform support, or
Rust dependency policy.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm audit`
- `pnpm exec prettier --check '**/*'`
- `zizmor --pedantic .github/workflows`
